### PR TITLE
Fix genesis block reward value in GetBlockSubsidy

### DIFF
--- a/src/groestlcoin.cpp
+++ b/src/groestlcoin.cpp
@@ -51,7 +51,7 @@ extern "C" {
 
 using namespace std;
 
-static const int64_t nGenesisBlockRewardCoin = 1 * COIN;
+static const int64_t nGenesisBlockRewardCoin = 0;
 int64_t minimumSubsidy = 5.0 * COIN;
 static const int64_t nPremine = 240640 * COIN;
 


### PR DESCRIPTION
Not really a problem, just for sake of correctness.
https://github.com/Groestlcoin/groestlcoin/blob/b47e153ed08328fcc932888b96c56ac0cb3e2aec/src/groestlcoin.cpp#L390
According to ^^^ genesis block created 0 coins.

This also can be verified with command-line:
```
$ ./groestlcoin-cli  getblockhash 0
00000ac5927c594d49cc0bdb81759d0da8297eb614683d3acb62f0703b639023
$ ./groestlcoin-cli  getblock 00000ac5927c594d49cc0bdb81759d0da8297eb614683d3acb62f0703b639023 2
{
  "hash": "00000ac5927c594d49cc0bdb81759d0da8297eb614683d3acb62f0703b639023",
  ...
      "vout": [
        {
          "value": 0.00000000,
          "n": 0,
          "scriptPubKey": {
            "asm": "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f OP_CHECKSIG",
            "hex": "4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac",
            "reqSigs": 1,
            "type": "pubkey",
            "addresses": [
              "FeBhpvNkdtxC7K3LEVT8uqskzwC4mFYrhR"
            ]
          }
        }
      ],
   ...
}
```