### PR TITLE
linearize-data: Skip if header is 8 zero bytes

### DIFF
--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -19,6 +19,8 @@ import time
 from collections import namedtuple
 from binascii import hexlify, unhexlify
 
+import groestlcoin_hash
+
 settings = {}
 
 def hex_switchEndian(s):
@@ -48,15 +50,7 @@ def wordreverse(in_buf):
     return b''.join(out_words)
 
 def calc_hdr_hash(blk_hdr):
-    hash1 = hashlib.sha256()
-    hash1.update(blk_hdr)
-    hash1_o = hash1.digest()
-
-    hash2 = hashlib.sha256()
-    hash2.update(hash1_o)
-    hash2_o = hash2.digest()
-
-    return hash2_o
+    return groestlcoin_hash.getHash(blk_hdr, len(blk_hdr))
 
 def calc_hash_str(blk_hdr):
     hash = calc_hdr_hash(blk_hdr)
@@ -215,6 +209,8 @@ class BlockDataCopier:
             inMagic = inhdr[:4]
             if (inMagic != self.settings['netmagic']):
                 print("Invalid magic: " + hexlify(inMagic).decode('utf-8'))
+                if hexlify(inhdr).decode('utf-8') == '0000000000000000':
+                    continue
                 return
             inLenLE = inhdr[4:]
             su = struct.unpack("<I", inLenLE)


### PR DESCRIPTION
Jackie and I found that this fixes a problem because sometimes there is a string of 8 bytes with zero values. Also this script now requires `groestlcoin_hash` to be installed.